### PR TITLE
implement file name templates

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -493,6 +493,8 @@ function! vimwiki#base#generate_links(create, ...) abort
             " switch to [[URL|DESCRIPTION]] if caption is not empty
             " Link2 is the same for mardown syntax
             let link_tpl = vimwiki#vars#get_syntaxlocal('Link2')
+          else
+            let link_caption = link
           endif
         endif
         " Replace Url, Description

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -65,7 +65,7 @@ function! s:rx_escape(s) abort
   return escape(a:s, '.*+?[](){}^$|\\')
 endfunction
 
-function! s:timestamp_from_diary_day_link_from(path) abort
+function! s:timestamp_from_diary_day_link(path) abort
   let pref = s:rx_escape(vimwiki#vars#get_wikilocal('diary_rel_path'))
   let pat = s:rx_escape(s:diary_day_link_format())
   let loc = {}
@@ -90,7 +90,7 @@ endfunction
 
 function! s:diary_move_from_current(dir) abort
   let curfile = vimwiki#path#path_norm(expand('%:p'))
-  let stamp = s:timestamp_from_diary_day_link_from(curfile)
+  let stamp = s:timestamp_from_diary_day_link(curfile)
   if !stamp | return 0 | endif
   let stamp2 = s:change_day(stamp, a:dir)
   " echo stamp . ' '. stamp2 . ' ' .strftime("%Y-%m-%d %H:%M:%S %z", stamp2)

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -266,6 +266,8 @@ function! s:read_captions(files) abort
   " Return: <Dic>: key -> caption
   let result = {}
   let caption_level = vimwiki#vars#get_wikilocal('diary_caption_level')
+  let diary_file = vimwiki#path#path_norm(s:diary_index())
+  let diary_dir = fnamemodify(diary_file, ':h:~')
 
   for fl in a:files
     " Remove paths and extensions
@@ -298,6 +300,9 @@ function! s:read_captions(files) abort
     endif
 
     let fl_key = substitute(fnamemodify(fl, ':t'), vimwiki#vars#get_wikilocal('ext').'$', '', '')
+    let fl_path = substitute(fl, '^'.s:rx_escape(diary_dir).'[/\\]*', '', '')
+    let fl_path = substitute(fl_path, vimwiki#vars#get_wikilocal('ext').'$', '', '')
+    let fl_captions['path'] = fl_path
     let result[fl_key] = fl_captions
   endfor
   return result
@@ -308,7 +313,7 @@ function! vimwiki#diary#get_diary_files() abort
   " Return: <list> diary file names
   let rx = '^\d\{4}-\d\d-\d\d'
   let s_files = glob(vimwiki#vars#get_wikilocal('path').
-        \ vimwiki#vars#get_wikilocal('diary_rel_path').'*'.vimwiki#vars#get_wikilocal('ext'))
+        \ vimwiki#vars#get_wikilocal('diary_rel_path').'**/*'.vimwiki#vars#get_wikilocal('ext'))
   let files = split(s_files, '\n')
   call filter(files, 'fnamemodify(v:val, ":t") =~# "'.escape(rx, '\').'"')
 
@@ -528,7 +533,7 @@ function! vimwiki#diary#generate_diary_section() abort
           endif
 
           let bullet = vimwiki#lst#default_symbol().' '
-          let entry = substitute(top_link_tpl, '__LinkUrl__', fl, '')
+          let entry = substitute(top_link_tpl, '__LinkUrl__', get(captions,'path',fl), '')
           let entry = substitute(entry, '__LinkDescription__', topcap, '')
           let wiki_nr = vimwiki#vars#get_bufferlocal('wiki_nr')
           let extension = vimwiki#vars#get_wikilocal('ext', wiki_nr)


### PR DESCRIPTION
implement file name templates

example format in .vimrc:
```
let g:vimwiki_diary_path_format = '%y-%m/%Y-%m-%d'
````

limitations:
- file format should contain somewhere `%Y`, `%m` and `%d`. 
  - without this, the `timestamp_from_diary_day_link` wouldn't work
  - this is required for new next/prev day functionality which doesn't use the index page.
  - it would also be required for a new index generation (see next point)
- base file name should still follow basic y-m-d format, if you want to be able to generate the index
  - this actually wouldn't be too difficult to change, by modifying `function! s:group_links`, 
  - refactor of `function! s:timestamp_from_diary_day_link_from`
  - modify this function so it returns the Y/m/d dictionary, either in place of or in addition to the timestamp
  - modify group_links to get y/m/d via this new func.
